### PR TITLE
Fix typo in modset size script

### DIFF
--- a/total_modset_size.py
+++ b/total_modset_size.py
@@ -19,7 +19,7 @@ def format_bytes(num):
     if order > 6:
         return str(round(num / 10 ** 6, 2)) + " mb"
     if order > 3:
-        return str(round(num / 10 ** 3, 2)) + " mb"
+        return str(round(num / 10 ** 3, 2)) + " kb"
     else:
         return str(num) + " bytes"
 


### PR DESCRIPTION
Fixed a typo in modset sizing script where mod sizes of <1mb but >=1kb would be reported as 1000x larger than their actual size.