### PR TITLE
Fix presets that contain unlisted mods

### DIFF
--- a/total_modset_size.py
+++ b/total_modset_size.py
@@ -19,7 +19,7 @@ def format_bytes(num):
     if order > 6:
         return str(round(num / 10 ** 6, 2)) + " mb"
     if order > 3:
-        return str(round(num / 10 ** 3, 2)) + " mb"
+        return str(round(num / 10 ** 3, 2)) + " kb"
     else:
         return str(num) + " bytes"
 


### PR DESCRIPTION
The Steam Web API only returns a _publishedfileid_ for unlisted mods meaning scripts would crash when handling them. Unlisted mods now fallback on the name contained in the preset although their size cannot be easily determined so this is represented as NaN.