### PR TITLE
Add downloader clean and link modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Preset ingest scripts
+# Arma 3 Preset Ingest Scripts
 
 Just a few small scripts to ease dealing with arma presets and workshop collections.
 

--- a/compare_modset_deltas.py
+++ b/compare_modset_deltas.py
@@ -34,10 +34,20 @@ print("Common Mods:")
 for mod in commonMods:
     print(" - " + str(mod))
 
-print(modset1.name + " Mods:")
+if modset1.is_collection():
+    print(modset1.name + " Mods (" + modset1.get_url() + "):")
+else:
+    print(modset1.name + " Mods:")
+if len(modset1.mods) == 0:
+    print("None")
 for mod in modset1Only:
     print(" - " + str(mod))
 
-print(modset2.name + " Mods:")
+if modset2.is_collection():
+    print(modset2.name + " Mods (" + modset2.get_url() + "):")
+else:
+    print(modset2.name + " Mods:")
+if len(modset2.mods) == 0:
+    print("None")
 for mod in modset2Only:
     print(" - " + str(mod))

--- a/download_mods.py
+++ b/download_mods.py
@@ -65,6 +65,9 @@ args = parser.parse_args()
 
 modset = common.ModSet.from_collection_preset(args.modset)
 
+if args.symlink and args.output_path is None:
+    raise Exception("You must specify -o/--output-path to enable --symlink mode.")
+
 if args.update and not args.symlink:
     # No need to copy mods if they are symlinked.
     if args.output_path is None:

--- a/download_mods.py
+++ b/download_mods.py
@@ -76,7 +76,13 @@ if args.update:
 if args.clean:
     if not args.output_path is None:
         for mod_folder in glob.glob(args.output_path + "/@*"):
-            if not mod_folder.split("/@")[1] in [m.name for m in modset.mods]:
+            mod_name = mod_folder.split("/@")[1]
+            if not mod_name in [m.name for m in modset.mods]:
+                print(
+                    "Deleting @"
+                    + mod_name
+                    + " because clean mode is enabled an this mod it not the in specified modset."
+                )
                 shutil.rmtree(mod_folder)
     else:
         raise Exception("You must set -o/--output-path to enable --clean mode.")

--- a/download_mods.py
+++ b/download_mods.py
@@ -12,10 +12,10 @@ WORKSHOP_CONTENT_DIR = "steamapps/workshop/content/" + APPID
 
 parser = argparse.ArgumentParser(
     prog="download_mods.py",
-    usage="%(prog)s [preset-collection] [options]",
+    usage="%(prog)s [modset] [options]",
     description="Download the mods in a preset or workshop collection using steamcmd.",
 )
-parser.add_argument("preset_collection")
+parser.add_argument("modset")
 parser.add_argument(
     "-s",
     "--steamcmd-path",
@@ -35,7 +35,7 @@ parser.add_argument(
     "-o",
     "--output-path",
     help=r"directory to move downloaded mods to. if this is set mods will be renamed to @{mod_name}. \
-    mods will not be moved by default.",
+    mods will not be moved by default",
     default=None,
 )
 parser.add_argument(
@@ -50,9 +50,14 @@ parser.add_argument(
     re-downloaded",
     action="store_true",
 )
+parser.add_argument(
+    "--clean",
+    help="any folders prefixed with @ in [output-path] not in the current modset will be deleted",
+    action="store_true",
+)
 args = parser.parse_args()
 
-modset = common.ModSet.from_collection_preset(args.preset_collection)
+modset = common.ModSet.from_collection_preset(args.modset)
 
 if args.update:
     if not args.output_path is None:
@@ -67,6 +72,15 @@ if args.update:
         print("Done")
     else:
         raise Exception("You must set -o/--output-path to enable --update mode.")
+
+if args.clean:
+    if not args.output_path is None:
+        for mod_folder in glob.glob(args.output_path + "/@*"):
+            if not mod_folder.split("/@")[1] in [m.name for m in modset.mods]:
+                shutil.rmtree(mod_folder)
+    else:
+        raise Exception("You must set -o/--output-path to enable --clean mode.")
+
 
 steamcmd_cmd = [
     args.steamcmd_path,

--- a/modset_common.py
+++ b/modset_common.py
@@ -20,7 +20,7 @@ class Mod:
 
     def __init__(self, name, id, size):
         name = name.replace(" ", "_")
-        self.name = re.sub(r"[\\\/:*?\"<>|]", " ", name)
+        self.name = re.sub(r"[\\\/:*?\"<>|]", "", name)
         self.id = id
         self.size = size
 

--- a/modset_common.py
+++ b/modset_common.py
@@ -1,4 +1,5 @@
 import os
+import re
 import sys
 import requests
 from bs4 import BeautifulSoup
@@ -18,10 +19,8 @@ class Mod:
         return Mod(details["title"], details["publishedfileid"], details["file_size"])
 
     def __init__(self, name, id, size):
-        if sys.platform == "linux" or sys.platform == "linux2":
-            self.name = name.replace(" ", "_")
-        else:
-            self.name = name
+        name = name.replace(" ", "_")
+        self.name = re.sub(r"[\\\/:*?\"<>|]", " ", name)
         self.id = id
         self.size = size
 

--- a/total_modset_size.py
+++ b/total_modset_size.py
@@ -28,10 +28,21 @@ modset = common.ModSet.from_collection_preset(args.modset)
 
 
 total_size = 0
-modset.mods = sorted(modset.mods, key=lambda mod: mod.size)
+unknown_size = False
+modset.mods = sorted(modset.mods, key=lambda mod: -1 if mod.size is None else mod.size)
 for mod in modset.mods:
-    mod_size = mod.size
-    total_size += mod_size
-    print("'" + mod.name + "' is " + format_bytes(mod_size))
+    if not mod.size is None:
+        total_size += mod.size
+        print(str(mod) + " is " + format_bytes(mod.size))
+    else:
+        print(str(mod) + " size is unknown")
+        unknown_size = True
 
-print("Preset contains " + format_bytes(total_size) + " of mods.")
+if unknown_size:
+    print(
+        "Preset contains at least "
+        + format_bytes(total_size)
+        + " of mods (some mods were unlisted or private)."
+    )
+else:
+    print("Preset contains " + format_bytes(total_size) + " of mods.")

--- a/total_modset_size.py
+++ b/total_modset_size.py
@@ -19,7 +19,7 @@ def format_bytes(num):
     if order > 6:
         return str(round(num / 10 ** 6, 2)) + " mb"
     if order > 3:
-        return str(round(num / 10 ** 3, 2)) + " mb"
+        return str(round(num / 10 ** 3, 2)) + " kb"
     else:
         return str(num) + " bytes"
 


### PR DESCRIPTION
Added two new modes to download_mods.py:
- Clean mode removes directories prefixed with @ that are not contained in a modset but are in the destination directory.
- Link mode symlinks the mods to the destination directory rather than copying
- Fixed crashes for modset scripts when handling unlisted workshop items