### PR TITLE
Modset combine script

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,3 +51,11 @@ Moves the .bikey files in the downloaded mods contained in a preset or workshop 
 ```
 py ./collect_keys.py <path-to-preset-or-collection-id>
 ```
+
+## `combine_modset.py`
+
+Adds and subtracts modsets to produce an output preset.
+
+```
+py ./combine_modset.py <output> --add <list-of-paths-to-presets-or-collection-ids> --subtract <list-of-paths-to-presets-or-collection-ids>
+```

--- a/collect_keys.py
+++ b/collect_keys.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import modset_common as common
 import argparse
 import shutil

--- a/combine_modset.py
+++ b/combine_modset.py
@@ -1,0 +1,42 @@
+import os
+import modset_common as common
+import argparse
+
+parser = argparse.ArgumentParser(
+    prog="combine_modset.py",
+    usage="%(prog)s [output] [options]",
+    description="Adds and subtracts modsets to produce a single preset.",
+)
+parser.add_argument("output")
+parser.add_argument(
+    "-a",
+    "--add",
+    help="a modset to add",
+    nargs="+",
+)
+parser.add_argument(
+    "-s",
+    "--subtract",
+    help="a modset to subtract (any mods in these sets will not be included even if they are added more than once)",
+    nargs="+",
+)
+args = parser.parse_args()
+
+mods = []
+for addition in args.add:
+    modset = common.ModSet.from_collection_preset(addition)
+    for mod in modset.mods:
+        if not mod in mods:
+            mods.append(mod)
+
+for subtraction in args.subtract:
+    modset = common.ModSet.from_collection_preset(subtraction)
+    for mod in modset.mods:
+        try:
+            mods.remove(mod)
+        except ValueError:
+            pass
+
+name = os.path.splitext(os.path.basename(args.output))[0]
+modset = common.ModSet(name, mods)
+modset.export_preset(args.output)

--- a/combine_modset.py
+++ b/combine_modset.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import os
 import modset_common as common
 import argparse

--- a/combine_modset.py
+++ b/combine_modset.py
@@ -29,6 +29,9 @@ for addition in args.add:
         if not mod in mods:
             mods.append(mod)
 
+if len(mods) == 0:
+    raise Exception("No mods specified to add. Use the -a argument to add modsets.")
+
 for subtraction in args.subtract:
     modset = common.ModSet.from_collection_preset(subtraction)
     for mod in modset.mods:

--- a/compare_modset_deltas.py
+++ b/compare_modset_deltas.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import modset_common as common
 import sys
 import os

--- a/download_mods.py
+++ b/download_mods.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import modset_common as common
 import subprocess
 import argparse

--- a/extract_load_order.py
+++ b/extract_load_order.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import modset_common as common
 import argparse
 

--- a/extract_mod_ids.py
+++ b/extract_mod_ids.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import modset_common as common
 import argparse
 

--- a/modset_common.py
+++ b/modset_common.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import os
 import re
 import io

--- a/modset_constants.py
+++ b/modset_constants.py
@@ -26,7 +26,7 @@ PRESET_FORMAT = """
 <html>
     <head>
         <meta name="arma:Type" content="preset" />
-        <meta name="arma:PresetName" content="Black Sword Biceps" />
+        <meta name="arma:PresetName" content="{preset_name}" />
         <meta name="generator" content="A3PresetTools - https://github.com/AgentBlackout/A3PresetTools" />
         <title>Arma 3</title>
         <link href="https://fonts.googleapis.com/css?family=Roboto" rel="stylesheet" type="text/css" />

--- a/modset_constants.py
+++ b/modset_constants.py
@@ -1,0 +1,117 @@
+STEAM_URL_FORMAT = "http://steamcommunity.com/sharedfiles/filedetails/?id="
+
+PUBLISHED_FILE_DETAILS_ENDPOINT = (
+    "https://api.steampowered.com/ISteamRemoteStorage/GetPublishedFileDetails/v1/"
+)
+
+COLLECTION_DETAILS_ENDPOINT = (
+    "https://api.steampowered.com/ISteamRemoteStorage/GetCollectionDetails/v1/"
+)
+
+STEAM_MOD_FORMAT = """
+            <tr data-type="ModContainer">
+                <td data-type="DisplayName">{mod_name}</td>
+                <td>
+                    <span class="from-steam">Steam</span>
+                </td>
+                <td>
+                    <a href="{mod_url}" data-type="Link">{mod_url}</a>
+                </td>
+            </tr>"""
+
+PRESET_FORMAT = """
+<?xml version="1.0" encoding="utf-8"?>
+<html>
+    <head>
+        <meta name="arma:Type" content="preset" />
+        <meta name="arma:PresetName" content="Black Sword Biceps" />
+        <meta name="generator" content="A3PresetTools - https://github.com/AgentBlackout/A3PresetTools" />
+        <title>Arma 3</title>
+        <link href="https://fonts.googleapis.com/css?family=Roboto" rel="stylesheet" type="text/css" />
+        <style>
+body {{
+    margin: 0;
+	padding: 0;
+	color: #fff;
+	background: #000;
+}}
+
+body, th, td {{
+	font: 95%/1.3 Roboto, Segoe UI, Tahoma, Arial, Helvetica, sans-serif;
+}}
+
+td {{
+    padding: 3px 30px 3px 0;
+}}
+
+h1 {{
+    padding: 20px 20px 0 20px;
+    color: white;
+    font-weight: 200;
+    font-family: segoe ui;
+    font-size: 3em;
+    margin: 0;
+}}
+
+em {{
+    font-variant: italic;
+    color:silver;
+}}
+
+.before-list {{
+    padding: 5px 20px 10px 20px;
+}}
+
+.mod-list {{
+    background: #222222;
+    padding: 20px;
+}}
+
+.dlc-list {{
+    background: #222222;
+    padding: 20px;
+}}
+
+.footer {{
+    padding: 20px;
+    color:gray;
+}}
+
+.whups {{
+    color:gray;
+}}
+
+a {{
+    color: #D18F21;
+    text-decoration: underline;
+}}
+
+a:hover {{
+    color:#F1AF41;
+    text-decoration: none;
+}}
+
+.from-steam {{
+    color: #449EBD;
+}}
+.from-local {{
+    color: gray;
+}}
+
+    </style>
+</head>
+<body>
+    <h1>Arma 3  - Preset <strong>{preset_name}</strong></h1>
+    <p class="before-list">
+      <em>Drag this file or link to it to Arma 3 Launcher or open it Mods / Preset / Import.</em>
+    </p>
+    <div class="mod-list">
+        <table>
+{mod_list}
+        </table>
+    </div>
+    <div class="footer">
+      <span>Created by Arma 3 Launcher by Bohemia Interactive.</span>
+    </div>
+</body>
+</html>"""

--- a/modset_constants.py
+++ b/modset_constants.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 STEAM_URL_FORMAT = "http://steamcommunity.com/sharedfiles/filedetails/?id="
 
 PUBLISHED_FILE_DETAILS_ENDPOINT = (
@@ -115,3 +117,6 @@ a:hover {{
     </div>
 </body>
 </html>"""
+
+if __name__ == "__main__":
+    print("Don't run this, this is a common library!")

--- a/total_modset_size.py
+++ b/total_modset_size.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import modset_common as common
 import argparse
 import math

--- a/total_modset_size.py
+++ b/total_modset_size.py
@@ -19,7 +19,7 @@ def format_bytes(num):
     if order > 6:
         return str(round(num / 10 ** 6, 2)) + " mb"
     if order > 3:
-        return str(round(num / 10 ** 3, 2)) + " mb"
+        return str(round(num / 10 ** 3, 2)) + " kb"
     else:
         return str(num) + " bytes"
 


### PR DESCRIPTION
- Added a script for adding and subtracting modsets to produce an output a3 preset.
- Added shebangs so that scripts can be run directly from bash without explicitly invoking the python interpreter.
- Migrated string constants to a shared file.