### PR TITLE
download_mods.py refactor

### DIFF
--- a/download_mods.py
+++ b/download_mods.py
@@ -84,15 +84,15 @@ if args.clean:
     expected_mod_folders = [get_mod_target_path(mod) for mod in modset.mods]
 
     for mod_folder in glob.glob(args.output_path + "/@*"):
-        if not mod_folder in expected_mod_folders:
+        if not os.path.abspath(mod_folder) in expected_mod_folders:
             print(
                 "Deleting '"
                 + mod_folder
             )
             shutil.rmtree(mod_folder)
-    print("Done")
+    print("Done\n")
 
-print("Preparing mod folders... ", end="", flush=True) 
+print("Preparing mod folders... ", flush=True, end="") 
 for mod in modset.mods:
     source = get_mod_source_path(mod)
     target = get_mod_target_path(mod)
@@ -134,7 +134,7 @@ if steamcmd.returncode != 0:
         "steamcmd failed for some reason. Please review its output."
     )
 else:
-    print("steamcmd done.")
+    print("steamcmd done.\n")
 
 def rename_files_lower(directory):
     for mod_file in glob.glob(glob.escape(directory) + "/*"):
@@ -151,7 +151,7 @@ if sys.platform == "linux" or sys.platform == "linux2":
         rename_files_lower(args.output_path + "/@" + mod.name)
     print("Done")
 
-print("Cleaning up download path... ", end="")
+print("Cleaning up download path... ", flush=True, end="")
 for mod in modset.mods:
     source = get_mod_source_path(mod)
     if not os.path.islink(source):

--- a/download_mods.py
+++ b/download_mods.py
@@ -46,7 +46,7 @@ parser.add_argument(
     default=".",
 )
 parser.add_argument(
-    "--readible-names",
+    "--readable-names",
     help="use escaped mod names for folder directories (by default mod ids are used)",
     action="store_true"
 )
@@ -73,7 +73,7 @@ def get_mod_target_path(mod: common.Mod = None):
     if mod is None:
         return dir
     
-    if args.readible_names:
+    if args.readable_names:
         return dir + "/@" + mod.name
     else:
         return dir + "/@" + mod.id

--- a/extract_load_order.py
+++ b/extract_load_order.py
@@ -8,6 +8,11 @@ parser = argparse.ArgumentParser(
     usage="%(prog)s [preset] [options]",
     description="Reads a presets mods out in the assigned load order formatted for use in the arma '-mods=' argument.",
 )
+parser.add_argument(
+    "--readable-names",
+    help="use escaped mod names for folder directories (by default mod ids are used), see download_mods.py",
+    action="store_true"
+)
 parser.add_argument("preset")
 args = parser.parse_args()
 
@@ -15,6 +20,11 @@ preset = common.ModSet.from_preset(args.preset)
 
 loadString = ""
 for mod in preset.mods:
-    loadString += "@" + mod.name + ";"
+    loadString += "@"
+    if args.readable_names:
+        loadString += mod.name
+    else:
+        loadString += mod.id
+    loadString += ";"
 
 print(loadString)

--- a/modset_constants.py
+++ b/modset_constants.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 
+ARMA3_APPID = "107410"
+
 STEAM_URL_FORMAT = "http://steamcommunity.com/sharedfiles/filedetails/?id="
 
 PUBLISHED_FILE_DETAILS_ENDPOINT = (


### PR DESCRIPTION
**This PR introduces a change in the default naming of mod folders. To restore the previous behaviour (and avoid redownloading your mods) use the --readable-names flag (this also applies to the extract_load_order.py script).**

- Update argument descriptions for clarity
- Rename --steamcmd-path to --steamcmd
- Remove --symlink and --update (now obsolete)
- Move constants into modset_constants.py
- Add --readable-names (by default mods use now @[mod_id] instead of @[escaped_mod_name] as before)
- Rewrite downloading code to use temporary symlinks (from output directory to download directory) instead of copying or moving
- Flush some print expressions (to remove delay in printing)
- Update extract_load_order.py to be compatible with new default download_mods.py behaviour